### PR TITLE
Documentation for DPT-249.600 and update for DPT-251.600

### DIFF
--- a/source/includes/2_knx_api_and_datapoint_types/_33-1-DPT249-600.md
+++ b/source/includes/2_knx_api_and_datapoint_types/_33-1-DPT249-600.md
@@ -1,0 +1,63 @@
+## DPT\_249\_600
+
+This DataPoint Type is used for controlling the Color Temperature and/or Brightness transition via a single group object.
+
+###### Available from KNX Routing Gateway driver version 48.
+
+| Parameters  | Description |
+| --- | --- |
+| TIME | Time (0 - 6553500) in milliseconds it takes to ramp to TEMPERATURE/BRIGHTNESS. Can be nil in which case the ramping will be immediate. |
+| TEMPERATURE | Color temperature in Kelvin (0 - 65535). Can be nil if only BRIGHTNESS should be ramped |
+| BRIGHTNESS | Brightness of the color temperature (0% - 100%). Can be nil if only TEMPERATURE should be ramped |
+
+
+### Example
+
+
+```lua
+-- Ramp to color temperature and brightness for 1s:
+
+tParams["GROUP_ADDRESS"] = Properties[“Channel 1 Address”]
+tParams["DATA_POINT_TYPE"] = “DPT_249_600”
+tParams["TIME"] = 1000
+tParams["TEMPERATURE"] = 4500
+tParams["BRIGHTNESS"] = 50
+C4:SendToProxy(1, ”SEND_TO_KNX”, tParams)
+```
+
+
+```lua
+-- Ramp to color temperature only for 1s:
+
+tParams["GROUP_ADDRESS"] = Properties[“Channel 1 Address”]
+tParams["DATA_POINT_TYPE"] = “DPT_249_600”
+tParams["TIME"] = 1000
+tParams["TEMPERATURE"] = 4500
+tParams["BRIGHTNESS"] = nil
+C4:SendToProxy(1, ”SEND_TO_KNX”, tParams)
+```
+
+
+
+
+```lua
+-- Ramp to brightness only for 1s:
+
+tParams["GROUP_ADDRESS"] = Properties[“Channel 1 Address”]
+tParams["DATA_POINT_TYPE"] = “DPT_249_600”
+tParams["TIME"] = 1000
+tParams["TEMPERATURE"] = nil
+tParams["BRIGHTNESS"] = 50
+C4:SendToProxy(1, ”SEND_TO_KNX”, tParams)
+```
+
+```lua
+-- Ramp to temperature and brightness immediatly:
+
+tParams["GROUP_ADDRESS"] = Properties[“Channel 1 Address”]
+tParams["DATA_POINT_TYPE"] = “DPT_249_600”
+tParams["TIME"] = nil 
+tParams["TEMPERATURE"] = 4500
+tParams["BRIGHTNESS"] = 50
+C4:SendToProxy(1, ”SEND_TO_KNX”, tParams)
+```

--- a/source/includes/2_knx_api_and_datapoint_types/_33-DPT251-600.md
+++ b/source/includes/2_knx_api_and_datapoint_types/_33-DPT251-600.md
@@ -40,3 +40,44 @@ tParams["B"] = nil
 tParams["W"] = 25
 C4:SendToProxy(1, ”SEND_TO_KNX”, tParams)
 ```
+
+Note that the R,G,B,W parameters are integer values. If a greater resolution is needed the following parameters can be used:
+
+###### Available from KNX Routing Gateway driver version 48.
+
+| Parameters  | Description |
+| --- | --- |
+| R\_BYTE | Red color level (0 to 255) or nil if not used |
+| G\_BYTE | Green color level (0 to 255) or nil if not used |
+| B\_BYTE | Blue color level (0 to 255) or nil if not used |
+| W\_BYTE | White color level (0 to 255) or nil if not used |
+
+
+### Example
+
+
+```lua
+-- The equivalent of sending full RGBW color using the example above would be:
+
+tParams["GROUP_ADDRESS"] = Properties[“Channel 1 Address”]
+tParams["DATA_POINT_TYPE"] = “DPT_251_600”
+tParams["R_BYTE"] = 255 --100
+tParams["G_BYTE"] = 191 --75
+tParams["B_BYTE"] = 127 --50
+tParams["W_BYTE"] = 64 --25
+C4:SendToProxy(1, ”SEND_TO_KNX”, tParams)
+```
+
+
+
+```lua
+-- Send only Red and White color levels:
+
+tParams["GROUP_ADDRESS"] = Properties[“Channel 1 Address”]
+tParams["DATA_POINT_TYPE"] = “DPT_251_600”
+tParams["R_BYTE"] = 255 --100
+tParams["G_BYTE"] = nil
+tParams["B_BYTE"] = nil
+tParams["W_BYTE"] = 64 --25
+C4:SendToProxy(1, ”SEND_TO_KNX”, tParams)
+```


### PR DESCRIPTION
Added DPT-249.600 (Brightness Color Temperature Transition)
Updated DPT-251.600 with BYTE fields for sending data in the range 0-255